### PR TITLE
Adding draft principles and correcting references carried over from addr-cm

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,7 +38,7 @@ For more information about these vocabularies, contact:
 GeoResources Division +
 Department of Natural Resources and Mines, Manufacturing, and Regional and Rural Development +
 Queensland Government +
-QldPlaceNamesd@resources.qld.gov.au
+QldPlaceNames@resources.qld.gov.au
 
 For further information, please visit:
 

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 _This proposed standard is based on the draft https://icsm-au.github.io/addr-creation-maintenance/doc.html[Australian Addressing Creation & Maintenance Standard] with which it will be aligned and cross-referenced._
 
-_This proposed standard will be dependent on the https://linked.data.gov.au/def/gn[Geographical Names Model] when it's approved as a standard, much like the_ Addressing Creation & Maintenance Standard _is dependent on the https://linked.data.gov.au/def/addr[Address Model]._
+_This proposed standard will be dependent on the https://linked.data.gov.au/def/gn[Geographical Names Model] when it's approved as a standard, much like the Addressing Creation & Maintenance Standard is dependent on the https://linked.data.gov.au/def/addr[Address Model]._
 
 This proposed standard is rendered on, as it is being developed, at:
 
@@ -14,12 +14,12 @@ We encourage all contributions to this Standard!
 
 Please contribute by:
 
-. Raising concerns/ideas within ICSM's Address Working Group
+. Raising concerns/ideas within ICSM's Place Names Working Group
 . Creating Issue tickets within this repository's Issue Tracker
-.. at https://github.com/Spatial-Information-QLD/addr-creation-maintenance/issues
+.. at https://github.com/icsm-au/gn-creation-maintenance/issues
 . Creating Pull Requests to absorb changes against the document source files
 .. the source files are in the `document/` folder of this repository
-.. Pull Requests should be lodged at https://github.com/Spatial-Information-QLD/addr-creation-maintenance/pulls
+.. Pull Requests should be lodged at https://github.com/icsm-au/gn-creation-maintenance/pulls
 
 _If creating Pull Requests is a new/unknown thing for you, please communicate with the contacts below for help._
 
@@ -27,7 +27,7 @@ _If creating Pull Requests is a new/unknown thing for you, please communicate wi
 
 The information in this repository is available for reuse under the https://creativecommons.org/licenses/by/4.0/[Creative Commons 4.0 license], see the LICENSE file for the deed.
 
-&copy; Intergovernmental Committee on Survey ing and Mapping, 2024
+&copy; Intergovernmental Committee on Surveying and Mapping, 2025
 
 
 == Contacts
@@ -36,9 +36,9 @@ For more information about these vocabularies, contact:
 
 *Spatial Information* +
 GeoResources Division +
-Department of Resources +
+Department of Natural Resources and Mines, Manufacturing, and Regional and Rural Development +
 Queensland Government +
-AddressQueensland@resources.qld.gov.au
+QldPlaceNamesd@resources.qld.gov.au
 
 For further information, please visit:
 

--- a/document/00-master.adoc
+++ b/document/00-master.adoc
@@ -14,4 +14,6 @@ include::03-preamble.adoc[]
 
 include::04-introduction.adoc[]
 
+include::05-principles.adoc[]
+
 include::99-bibliography.adoc[]

--- a/document/01-abstract.adoc
+++ b/document/01-abstract.adoc
@@ -1,7 +1,7 @@
 == Abstract
 
-This document specifies how addresses should be assigned and maintained to support Australia’s addressing infrastructure. It intends to help addressing authorities to fulfil custodial responsibilities and enable a consistent national approach to ongoing maintenance, accuracy and quality of addresses.
+This document specifies how place names should be assigned to support safety, cultural sensitivity and inclusivity. It intends to help naming authorities to fulfil custodial responsibilities and enable a consistent national approach to the naming of places.
 
-It is intended for use by agencies responsible for addressing, particularly Local Government in Australia. It should also be adhered to by developers where addressing authorities enable address numbering and road naming proposals.
+It is intended for use by agencies responsible for place naming, particularly State and Local Governments in Australia. It should also be adhered to by developers for road naming proposals and other entities assigning names to places in an official capacity, #such as buildings and public infrastructure#.
 
-This standard should be used in collaboration with national guidelines held by the Intergovernmental Committee on Surveying and Mapping (ICSM).
+#This standard should be used in collaboration with national guidelines held by the Intergovernmental Committee on Surveying and Mapping (ICSM).#

--- a/document/02-metadata.adoc
+++ b/document/02-metadata.adoc
@@ -2,19 +2,19 @@
 
 [width=75%, frame=none, grid=none, cols="2,5"]
 |===
-|**IRI** | `+https://linked.data.gov.au/def/gn-am+` +
+|**IRI** | `+https://linked.data.gov.au/def/gn-cm+` +
 (proposed)
-|**Name** | Address Creation & Maintenance Standard
-|**Description** | How addresses should be assigned and maintained to support Australia’s Geographical Naming infrastructure
+|**Name** | Australian Place Naming Principles
+|**Description** | How place names in Australia should be assigned to support safety, cultural sensitivity and inclusivity
 |**Created** | 2024-09-01
-|**Modified** | 2024-11-05
+|**Modified** | 2025-01-14
 |**Issued** | 0000-00-00
-|**Creator** | https://linked.data.gov.au/org/icsm-addrwg[ICSM's Geographical Naming Working Group]
+|**Creator** | https://linked.data.gov.au/org/icsm-pnwg[ICSM's Place Names Working Group (PNWG)]
 |**Publisher** | https://linked.data.gov.au/org/icsm[Intergovernmental Committee on Surveying & Mapping (ICSM)] (ICSM@ga.gov.au)
-|**Provenance** | This standard was created in 2024 by the ICSM Geographical Naming Working Group after the publication of ISO's publication in 2023 of ISO19160-2 Assigning and maintaining addresses for objects in the physical world and in 2024 of ICSM's publication of its Address Model. This standard is a profile of the former and instructions in the production of data conformant to the latter.
+|**Provenance** | #This standard was created in 2024 by the ICSM Place Names Working Group after the publication of ISO's publication in 2023 of ISO19160-2 Assigning and maintaining addresses for objects in the physical world and in 2024 of ICSM's publication of its Address Model. This standard is a profile of the former and instructions in the production of data conformant to the latter.#
 |**Status** | Draft
 |**Version** | 0.0.1
-|**Code Repository** | https://github.com/icsm-au/addr-creation-maintenance
+|**Code Repository** | https://github.com/icsm-au/gn-creation-maintenance
 |**License** | https://creativecommons.org/licenses/by/4.0/[Creative Commons Attribution 4.0 International (CC BY 4.0)]
 |**Copyright** | &copy; Intergovernmental Committee on Surveying & Mapping, 2024
 |===

--- a/document/03-preamble.adoc
+++ b/document/03-preamble.adoc
@@ -1,6 +1,17 @@
 == Preamble
 
-=== Scope
+=== Foreword
+In Australia there is no overarching naming authority. The ICSM PNWG brings together place name authorities from both Australia and New Zealand, working collaboratively to establish modern, inclusive, and consistent practices that reflect the evolving needs and values of our diverse communities. The PNWG has developed the Australian Place Naming Principles to provide a consistent and unified approach to place naming across the country.
+
+The principles replace the previous Principles for the Consistent Use of Place Names and are designed to address contemporary community expectations, with a particular focus on safety, cultural sensitivity and inclusivity. It recognises the critical role place naming plays in supporting a range of functions, including economic development, research, conservation, service delivery, and in reflecting the cultural identity and values of Australia.
+
+Aligned with the resolutions set out by the United Nations Group of Experts on Geographical Names, the principles adhere to international best practices while supporting Australian government authorities in updating and aligning local place naming policies. This ensures greater effectiveness in public services and better represents the diverse communities across the nation.
+
+The PNWG advocates for place naming that is inclusive and reflective of the diversity within our communities. In particular, the group acknowledges the significance of place names in promoting the wider use and appreciation of Aboriginal and Torres Strait Islander languages and cultures.
+
+While this document provides valuable guidance, the PNWG recognises that each state and territory in Australia has its own policies and practices. This document does not address the determination of state or territory names and boundaries, or Traditional First Nations Country or language group names and boundaries.
+
+=== #Scope#
 
 This document is a Profile of <<ISO19160-2, ISO 19160-2:2023, Addressing – Part 2: Assigning and maintaining addresses for objects in the physical world>>.
 
@@ -10,7 +21,7 @@ This document focuses on assigning and maintaining addresses that allow the unam
 
 This standard provides requirements for addressing authorities to assign addresses, record the related information, and signage related to addressing components.
 
-=== Normative References
+=== #Normative References#
 
 The following standard is needed for the application of this Australian Profile:
 
@@ -27,7 +38,7 @@ The following document defines the addressing model used for address records:
 
 * <<ADDR2024, ICSM's Address Model>>
 
-=== Terms & Definitions
+=== #Terms & Definitions#
 
 [[access-point]] access point:: The position along a thoroughfare (road or water feature) where the public would normally access an address site. SOURCE: this standard
 
@@ -51,22 +62,41 @@ The following document defines the addressing model used for address records:
 
 [[alternative-name]] alternative name:: a name that is an alternative name to another name for the same feature. SOURCE: <<ANZ4819, ANZ4819>>
 
-[[dual-name]] dual name:: a name that consists of two official names that must be used together, usually one indigenous and one European (e.g. ‘Aoraki/Mount Cook’). SOURCE: <<ANZ4819, ANZ4819>>
+[[dual-name]] dual name:: dual name is the approach of assigning two names, with two different cultural origins, to a geographical feature.
 
 [[formed]] formed:: in relation to a road, means that it is physically constructed or prepared for passage by vehicles or pedestrians. SOURCE: <<ANZ4819, ANZ4819>>
 
-[[geocode]] geocode:: a point feature for an address indicating a geometry. SOURCE: this standard
+[[gazetteer]] gazetteer:: an authorised compendium of approved place names for a State, Territory or Nation or Nations.
 
-[[locality]] locality:: a named geographical area defining a community or area of interest, which may be rural or urban in character, and is usually a suburb in the latter case. SOURCE: <<ANZ4819, ANZ4819>>
+[[generic-term]] generic term:: a part of a place name that indicates the type of geographical or topographical feature of a place.
+For example, ‘Park’ is a generic term used in the place name, ‘Karakai Park’, and ‘Bay’ is a generic term used in the place name ‘Botany Bay’.
+The generic term can differ from the object category. For example, a feature can be called ‘Karakai Park’ and have an object category of ‘Reserve’.
+
+[[geocode]] geocode:: a point feature for an address indicating a geometry. SOURCE: https://linked.data.gov.au/def/addr-cm/[Address Creation & Maintenance Standard]
+
+[[geographical-feature]] geographical feature:: A feature of (or relating to) the geography to refer to the characteristics of a certain location.
+
+[[locality]] locality:: #a named geographical area defining a community or area of interest, which may be rural or urban in character, and is usually a suburb in the latter case. SOURCE: <<ANZ4819, ANZ4819>>.# +
+commonly referred to as a ‘suburb’ in urban areas, is an administrative area over a defined geographical area, for the creation of valid addresses that can be uniquely and clearly identified. +
+#*or* use the definition from  the geographic object categories vocab:# +
+a bounded area distinguished for its community and/or landscape characteristics: in metropolitan areas it is commonly referred to as a ‘suburb’; it provides an official reference point for addressing purposes. SOURCE: https://linked.data.gov.au/def/go-categories/locality[concept of 'Locality' within the Geographical Object Categories vocabulary]
 
 [[IRI]] IRI:: Internationalized Resource Identifiers, IRIs, are a sequence of characters from the
    Universal Character Set. SOURCE: <<ISO10646, ISO10646>>
+
+[[official-names]] official name:: a place name approved by a naming authority and included in gazetteers of the respective jurisdiction(s)
+
+[[place]] place:: a location, especially one regarded as an entity and identifiable by name
+
+[[place-name]] place name:: an official or unofficial name given by a naming authority or organisation to a place
 
 [[preferred-address]] preferred address:: the assigned address that is preferred for usage and refers to the main access point to an address site. SOURCE: this standard
 
 [[primary-address-site]] primary address site:: an address site that is not contained within another address site. It may contain a sub-address site. SOURCE: <<ANZ4819, ANZ4819>>
 
 [[profile]] profile:: set of one or more base standards or subsets of base standards, and, where applicable, the identification of chosen clauses, classes, options and parameters of those base standards, that are necessary for accomplishing a particular function. SOURCE: <<ISO19160-2, ISO19160-2>>
+
+[[road]] road:: any public or private land-based thoroughfare or course navigable by vehicle or foot
 
 [[sub-address]] sub-address:: an address number element that refers to a sub-address site. SOURCE: This standard>>
 
@@ -76,7 +106,13 @@ The following document defines the addressing model used for address records:
 
 [[thoroughfare-address]] thoroughfare address:: an address that is assigned with reference to the thoroughfare it is accessed from, for example a road or water feature. SOURCE: this standard
 
-=== Conformance
+[[topographical-feature]] topographical feature:: the physical arrangement and characteristics of geographical features (both ‘natural’ and ‘human constructed’) of an area on the Earth’s surface
+
+[[unofficial-names]] unofficial names:: the State, Territory or other naming authority may recognise alternative names within a gazetteer or related databases at their discretion. This may include recorded names, spelling variants, historic names or unapproved names. Collectively, these are referred to as unofficial names
+
+[[vocabulary]] vocabulary:: a controlled list, glossary, dictionary of the words used to define a place – its features, type and associations
+
+=== #Conformance#
 
 Keywords used to signify requirements in this document are those defined by <<RFC2119, RFC2119>> and they are:
 
@@ -94,7 +130,7 @@ For process and information to be conformant with this standard, the imperatives
 
 Address information created following processes outlined in this standard _MUST_ conform to the <<ADDR2024, ICSM Address Model>> with conformance to it tested as per it's https://linked.data.gov.au/def/addr#AnnexB[Annex B: Validation] section.
 
-=== Namespaces
+=== #Namespaces#
 
 Namespaces, in this document's context, are managed <<IRI, IRIs>> which allow further IRIs to be created within their scope. Namespaces are allocated to macro data objects and provide IRIs for all the micro data objects within that object.
 
@@ -114,8 +150,8 @@ The prefixed namespaces used in this document are:
 |===
 |Prefix | Namespace | Description
 
-| `*addr*` | `*+https://linked.data.gov.au/def/addr/+*` | <<ADDR2024, ICSM's  Address Model>>
-| `*addrcm*` | `*+https://linked.data.gov.au/def/addrcm/+*` | *This Document*
+| `addr` | `+https://linked.data.gov.au/def/addr/+` | <<ADDR2024, ICSM's  Address Model>>
+| `addrcm` | `+https://linked.data.gov.au/def/addr-cm/+` | https://linked.data.gov.au/def/addr-cm/[Address Creation & Maintenance Standard]
 | `addreq` | `+https://linked.data.gov.au/def/addrcm-req/+` | https://linked.data.gov.au/def/addrcm-req[Address Creation & Maintenance Requirements Vocabulary]
 | `als` | `+https://linked.data.gov.au/def/address-lifecycle-stage-type/+` | https://linked.data.gov.au/def/lifecycle-stage-types[Address Lifecycle Stage Types vocabulary]
 | `apt` | `+https://linked.data.gov.au/def/address-part-type/+` | https://linked.data.gov.au/def/addr-part-types[Address Part Types vocabulary]
@@ -123,6 +159,8 @@ The prefixed namespaces used in this document are:
 | `cn` | `+https://linked.data.gov.au/def/cn/+` | https://linked.data.gov.au/def/cn[Compound Naming Model]
 | `ex` | `+http://example.com/+` | Generic examples
 | `geo` | `+http://www.opengis.net/ont/geosparql#+` | https://docs.ogc.org/is/22-047r1/22-047r1.html[OGC GeoSPARQL]
+| `gna` | `+https://vocabs.gsq.digital/v/vocab/defn:gn-affix+` | https://vocabs.gsq.digital/v/vocab/defn:gn-affix[Geographical Name Affix vocabulary] #(update to https://linked.data.gov.au/def/gn-affix once registered with AGLDWG)#
+| `gncm` | `+https://linked.data.gov.au/def/gn-cm/+` | *This document*
 | `gt` | `+http://www.opengis.net/ont/geocode-types/+` | https://linked.data.gov.au/def/geocode-types[Geocode types vocabulary]
 | `ls` | `+https://linked.data.gov.au/def/lifecycle/+` | https://linked.data.gov.au/def/lifecycle[Lifecycle Model]
 | `owl` | `+http://www.w3.org/2002/07/owl#+` | https://www.w3.org/TR/owl2-overview/[Web Ontology Language ontology]

--- a/document/05-principles.adoc
+++ b/document/05-principles.adoc
@@ -1,0 +1,140 @@
+== Australian Place Naming Principles
+=== Place naming across Australia is consistent
+All geographical features and areas, roads and localities in Australia should be named in a
+consistent way for the effective delivery of services and to enhance community cohesion.
+Jurisdictions can name other places as required by their legislation and policies.
+
+==== Language
+All place names should::
+. Be written in standard Australian English or, in an appropriate format for Aboriginal or
+Torres Strait Islander languages.
+. Use the standard Australia alphabet.
+. Have consistent spelling for names derived from the same source, e.g. Matodoro ridge
+and Matodoro trail.
+. Be easy to pronounce and spell.
+. Exceptions to the above may be appropriate for place names derived from different
+cultures Aboriginal and Torres Strait Islander languages.
+
+Place names should not::
+. Contain numbers, roman numerals, punctuation, abbreviations, acronyms or similar.
+. Start with the word ‘the’.
+. Contain cardinal indicators or qualifying terms, e.g. North, Southern, Upper, New. +
+Please refer to the #https://vocabs.gsq.digital/v/vocab/defn:gn-affix[affixes vocabulary] (replace link with https://linked.data.gov.au/def/gn-affix once registered with AGLDWG)#
+
+=== Place naming information is accurate and accessible
+
+As place names are a key descriptor in databases supporting a broad range of services,
+including emergency services, place naming information should be accurate, timely and readily
+accessible.
+
+==== Accessible
+. Place names must be assigned by a relevant naming authority in each State or
+Territory.
+. Published in a gazetteer,
+. Enduring, changes to existing names should only be considered when there is a
+compelling reason to do so.
+
+==== Unique
+. Avoiding duplication, a place name is a duplicate if it is identical with, or similar
+(in spelling or pronunciation) to another place name of the same feature type.
+. Uniqueness is particularly important for names forming a component of a street
+address, such as road and locality names. A road name, regardless of road type,
+should not duplicate an existing road name in the same locality, an adjoining
+locality, or in the same local government area. A new locality name should not
+duplicate any other locality name in Australia.
+
+==== Clearly described
+. A place name should have a clear description, that includes the extent of the
+feature it represents. The description should as much as possible align with the
+place names vocabulary (provide link).
+. Information to be captured includes the type of feature being named, eg, river,
+road or lake.
+. The description may also have associated origin information, including the
+reasoning for the name, any attached stories or background. For Aboriginal and
+Torres Strait Islander names, a recording of the pronunciation is encouraged.
+
+==== Places which cross State / Territory / jurisdictional boundaries
+. The name for any feature that crosses a State / Territory / jurisdictional boundary
+should be the same on both sides of that boundary and be decided by consensus
+with all responsible naming authorities.
+
+==== Offshore Places
+. States and Territories are responsible for the naming of island, water and
+undersea places within their legislated Coastal Waters and internal waters. The
+Australian Hydrographic Office should be advised of proposed, new and amended
+offshore place names for charting purposes.
+. Refer to the Australian Hydrographic Office for advice on the appropriate naming
+authority for offshore place names outside of Coastal Waters.
+. Limits of oceans and seas – as per ICSM Resolution R00/11/06, May 2001 –
+Changes to limits and nomenclature of the Oceans and Seas surrounding Australia
+require the approval of the ICSM before being forwarded to the International
+Hydrographic Organisation.
+
+==== Road names
+. The naming of roads should follow all principles in this document and:
+. All built public and private roads should be named,
+. A road should only have one name, other than part of a highway that is assigned
+a local name where it passes through a town or city. This includes where a road
+crosses administrative boundaries.
+. A road name should apply from one end of the road to the other i.e. the point
+where the road finishes or intersects with another road or roads.
+. A road name should include a road type, please refer to the road types
+vocabulary, e.g. Smith Street where street is the road type.
+. When a road is changed and it is no longer continuous, new names should be
+applied as appropriate to avoid confusion.
+
+=== Place names promote connection, inclusivity and the rights of others
+
+Place names promoting diversity and cultural inclusivity are encouraged. Aboriginal and Torres
+Strait Islander names in particular play an important role in reawakening language and culture.
+This may include the reinstating of Traditional place names, or the creation of new names
+derived from Aboriginal and Torres Strait Islander people's diverse languages.
+
+==== Connection
+. Place names should have a connection to the feature or area they represent.
+
+==== Aboriginal and Torres Strait Islander Place Names
+. Any place naming action should seek permission from the relevant Aboriginal
+and Torres Strait Islander peoples as the custodians of their language and culture,
+with consideration to the right to control their use.
+
+==== Dual Naming
+. Dual names are a way to assign two names, with two different cultural origins, to
+a geographical feature.
+. Dual names should not be applied to roads or localities.
+. Both names should be displayed on official maps and signage.
+. Dual names should be represented by name, space, forward slash (/), space,
+name e.g. Uluru / Ayers Rock.
+
+==== Commemorative Names
+. Place names can commemorate a person(s) or significant event and should
+have a connection to the place.
+. When commemorating a person(s) the name must be applied posthumously.
+Acts of bravery, community service and exceptional accomplishments are typical
+grounds for commemorating a person through place naming.
+. The place name should not include titles, honorifics or postnominals. For
+example: John Smith Park not John Smith AO Park, or Jane Smith Park not Dr Jane
+Smith Park.
+
+==== Unacceptable names
+. Place names must not be derogatory, discriminatory, frivolous, offensive, or in
+poor taste.
+. Contrived names should not be used, e.g combining two family names to create
+a single place name.
+. Place names should not be perceived as promoting commercial, or business
+interests.
+. Place names should not include words protected or restricted by
+Commonwealth or other legislation, unless the appropriate approvals are sought,
+e.g the term ANZAC, Royal and Defence words.
+. Place names should not infringe on any established or implied rights, e.g.
+copyright, trademarks and Indigenous Cultural and Intellectual Property (ICIP).
+
+==== Consultation
+. The impacted community or communities should be consulted for all new or
+altered place names.
+. If using Aboriginal or Torres Strait Islander language in a place name, it is
+important to engage in culturally appropriate consultation to obtain consent to use
+the name and record the meaning or story associated with the name.
+. Consent may also be required to capture supporting information, including
+historical background, spelling, information on pronunciation, origins, intellectual
+property, and cultural heritage.

--- a/document/99-bibliography.adoc
+++ b/document/99-bibliography.adoc
@@ -1,5 +1,10 @@
 == Bibliography
 
+[[Place-Names-Ontology]] Place Names Ontology:: Geoscience Australia, _Place Names Ontology_ (2018), https://linked.data.gov.au/def/placenames
+
+[[Geographical-Names-Model]] Geographical Names Model::
+Department of Natural Resources and Mines, Manufacturing, and Regional and Rural Development, _Geographical Names Model_ (2023), https://linked.data.gov.au/def/gn/guidance
+
 [[ADDR2024]] ADDR2024:: Intergovernmental Committee on Surveying & Mapping, _Address Model_ (2024). https://linked.data.gov.au/def/addr
 
 [[ADDR2035-1]] Addressing 2035 Strategy:: Intergovernmental Committee on Surveying and Mapping. _Addressing 2035 Strategy_ (2021). https://www.icsm.gov.au/publications/addressing-2035-strategy


### PR DESCRIPTION
Adding content from ICSM PNWG's draft Australian Place Naming Principles.
Updating invalid references carried over from the address creation and maintenance standard.